### PR TITLE
Stacks: Remove credit from readme

### DIFF
--- a/stacks/readme.txt
+++ b/stacks/readme.txt
@@ -29,12 +29,3 @@ This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
 MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU General Public License for more details.
-
-This theme bundles the following third-party resources:
-
-Image Credit Ben Dwyer
-License: CC0 1.0 Universal (CC0 1.0)
-License URL: https://creativecommons.org/publicdomain/zero/1.0/
-Sources: TBD
-
-TODO - add other resources


### PR DESCRIPTION
Removes this image credit as the image isn't used. Fixes #31.