### PR TITLE
Blue Note: Add font-sizes to theme.json

### DIFF
--- a/blue-note/theme.json
+++ b/blue-note/theme.json
@@ -146,6 +146,60 @@
 						}
 					]
 				}
+			],
+			"fontSizes": [
+				{
+					"fluid": false,
+					"size": "0.875rem",
+					"slug": "extra-small"
+				},
+				{
+					"fluid": {
+						"min": "0.875rem",
+						"max": "1rem"
+					},
+					"size": "1rem",
+					"slug": "small"
+				},
+				{
+					"fluid": false,
+					"size": "1.375rem",
+					"slug": "normal"
+				},
+				{
+					"fluid": {
+						"min": "1.375rem",
+						"max": "1.625rem"
+					},
+					"size": "1.625rem",
+					"slug": "medium"
+				},
+				{
+					"fluid": {
+						"min": "1.625rem",
+						"max": "1.875rem"
+					},
+					"size": "1.875rem",
+					"slug": "large"
+				},
+				{
+					"fluid": false,
+					"size": "2.5rem",
+					"slug": "extra-large"
+				},
+				{
+					"fluid": {
+						"min": "2.5rem",
+						"max": "3.75rem"
+					},
+					"size": "3.75em",
+					"slug": "extra-extra-large"
+				},
+				{
+					"fluid": false,
+					"size": "5rem",
+					"slug": "huge"
+				}
 			]
 		},
 		"useRootPaddingAwareAlignments": true


### PR DESCRIPTION
Paragraph, extra small. 14px

```
"fluid": false,
"size": "0.875rem",
"slug": "extra-small"
```

Paragraph, small, 16px, fluid
```
"fluid": {
		"min": "0.875rem",
		"max": "1rem"
},
"size": "1rem",
"slug": "small"
```

Paragraph  22px. No size name was added in the Figma file, so I went with "normal".
Also used for `H6`.

```
"fluid": false,
"size": "1.375rem",
"slug": "normal"
```

Paragraph medium, 26 px (min 22). Note this size does NOT match the size for `H5` which in Figma is 28px
```
"fluid": {
"min": "1.375rem",
"max": "1.625rem"
},
"size": "1.625rem",
"slug": "medium"
```

Paragraph large, 30px, (min 26). Note this size does NOT match the size for `H4` which in Figma is 34px
```
"fluid": {
"min": "1.625rem",
"max": "1.875rem"
},
"size": "1.875rem",
"slug": "large"
```

Paragraph, extra-large. 40px, also used for `H3` headings
This is set to fluid:false because the size is the same in the wide and mobile design.
```
"fluid": false,
"size": "2.5rem",
"slug": "extra-large"
```

`H2` headings, 60 px.  I am unsure of if this should be 68 px, which is the **smallest** size of the post title in the single post template, in mobile view.

"fluid": {
"min": "2.5rem",
"max": "3.75rem"
},
"size": "3.75em",
"slug": "extra-extra-large"


`H1 ` headings, 80px
```
"fluid": false,
"size": "5rem",
"slug": "huge"

```
