### PR TITLE
Remove invalid tag

### DIFF
--- a/stacks/style.css
+++ b/stacks/style.css
@@ -11,5 +11,5 @@ Version: 0.0.3
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 Text Domain: stacks
-Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, theme-options, threaded-comments, translation-ready, wide-blocks
+Tags: one-column, custom-colors, custom-menu, custom-logo, editor-style, featured-images, full-site-editing, rtl-language-support, threaded-comments, translation-ready, wide-blocks
 */


### PR DESCRIPTION
theme-options tag is only valid when Has theme options (customizer) https://make.wordpress.org/themes/handbook/review/required/theme-tags/