### PR TITLE
Update PHP min version required for themes

### DIFF
--- a/atlas/readme.txt
+++ b/atlas/readme.txt
@@ -2,7 +2,7 @@
 Contributors: wordpressdotorg
 Requires at least: 6.1
 Tested up to: 6.2
-Requires PHP: 5.6
+Requires PHP: 7.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/atlas/style.css
+++ b/atlas/style.css
@@ -6,7 +6,7 @@ Author URI: https://wordpress.org/
 Description: Atlas is a WordPress theme for anyone who wants to take their website to new heights, with a design that’s bold, beautiful, and centered on the cosmos.
 Requires at least: 6.1
 Tested up to: 6.2
-Requires PHP: 5.6
+Requires PHP: 7.4
 Version: 0.0.1
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/blue-note/readme.txt
+++ b/blue-note/readme.txt
@@ -2,7 +2,7 @@
 Contributors: the WordPress team
 Requires at least: 6.1
 Tested up to: 6.2
-Requires PHP: 8.0
+Requires PHP: 7.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/blue-note/style.css
+++ b/blue-note/style.css
@@ -6,7 +6,7 @@ Author URI: https://wordpress.org
 Description: 
 Requires at least: 6.1
 Tested up to: 6.2
-Requires PHP: 8.0
+Requires PHP: 7.4
 Version: 0.0.1
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/stacks/readme.txt
+++ b/stacks/readme.txt
@@ -2,7 +2,7 @@
 Contributors: wordpressdotorg
 Requires at least: 6.2
 Tested up to: 6.2
-Requires PHP: 5.7
+Requires PHP: 7.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/stacks/style.css
+++ b/stacks/style.css
@@ -6,7 +6,7 @@ Author URI: https://wordpress.org/themes/author/wordpressdotorg/
 Description: Stack your story. This theme is designed specifically to create slide decks that can be used as a presentation. The "Stacks" pattern can be included on any page or post.
 Requires at least: 6.2
 Tested up to: 6.2
-Requires PHP: 5.7
+Requires PHP: 7.4
 Version: 0.0.3
 License: GNU General Public License v2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/tt1-blocks/readme.txt
+++ b/tt1-blocks/readme.txt
@@ -2,7 +2,7 @@
 Contributors: wordpressdotorg
 Requires at least: 5.6
 Tested up to: 5.8
-Requires PHP: 5.6
+Requires PHP: 7.4
 Stable tag: 0.4.8
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html

--- a/tt1-blocks/style.css
+++ b/tt1-blocks/style.css
@@ -6,7 +6,7 @@ Author URI: https://wordpress.org/
 Description: TT1 Blocks is an experimental block-based version of the Twenty Twenty-One theme. It is built to leverage the full-site editing functionality that is being built in the Gutenberg plugin. This theme is not meant for use on a production site.
 Requires at least: 5.6
 Tested up to: 5.8
-Requires PHP: 5.6
+Requires PHP: 7.4
 Version: 0.4.8
 License: GNU General Public License v2 or later
 License URI: LICENSE


### PR DESCRIPTION
Let's update the themes to require the same [PHP version that WordPress does](https://wordpress.org/about/requirements/)