### PR TITLE
Blue note index pattern

### DIFF
--- a/blue-note/functions.php
+++ b/blue-note/functions.php
@@ -70,3 +70,4 @@ if ( ! function_exists( 'blue_note_styles' ) ) :
 endif;
 
 add_action( 'wp_enqueue_scripts', 'blue_note_styles' );
+add_action( 'enqueue_block_editor_assets', 'blue_note_styles' );

--- a/blue-note/functions.php
+++ b/blue-note/functions.php
@@ -11,7 +11,7 @@ function blue_note_register_block_styles() {
 			array(
 				'name'         => 'blue-note-slant-right',
 				'label'        => __( 'Slant right', 'blue-note' ),
-				'inline_style' => '.is-style-blue-note-slant-right{ transform: rotate(1deg); }',
+				'inline_style' => '.is-style-blue-note-slant-right{ transform: rotate(2deg); }',
 			)
 		);
 		register_block_style(
@@ -19,7 +19,7 @@ function blue_note_register_block_styles() {
 			array(
 				'name'         => 'blue-note-slant-left',
 				'label'        => __( 'Slant left', 'blue-note' ),
-				'inline_style' => '.is-style-blue-note-slant-left{ transform: rotate(-1deg); }',
+				'inline_style' => '.is-style-blue-note-slant-left{ transform: rotate(-2deg); }',
 			)
 		);
 	}
@@ -31,10 +31,10 @@ function blue_note_register_block_styles() {
 			'label' => __( 'Slanted images', 'blue-note' ),
 			'inline_style' => '
 				.is-style-blue-note-query-slant ul li:nth-child(odd) .wp-block-post-featured-image img {
-					transform: rotate(1deg);
+					transform: rotate(2deg);
 				}
 				.is-style-blue-note-query-slant ul li:nth-child(even) .wp-block-post-featured-image img {
-					transform: rotate(-1deg);
+					transform: rotate(-2deg);
 				}
 			',
 		)

--- a/blue-note/patterns/footer-default.php
+++ b/blue-note/patterns/footer-default.php
@@ -8,10 +8,10 @@
 ?>
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","right":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|60"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between","verticalAlignment":"top"}} -->
 <div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--60)">
-	
+
 	<!-- wp:group {"style":{"spacing":{"padding":{"top":"0","right":"0","bottom":"0","left":"0"}}},"layout":{"type":"constrained"}} -->
 	<div class="wp-block-group" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0">
-		<!-- wp:site-title /-->
+		<!-- wp:site-title {"level":0} /-->
 		<!-- wp:paragraph -->
 		<p><?php esc_html_e( 'Built with WordPress', 'blue-note' ); ?></p>
 		<!-- /wp:paragraph -->

--- a/blue-note/patterns/footer-large.php
+++ b/blue-note/patterns/footer-large.php
@@ -19,7 +19,7 @@
 
 <!-- wp:group {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
 <div class="wp-block-group"><!-- wp:group -->
-<div class="wp-block-group"><!-- wp:site-title /-->
+<div class="wp-block-group"><!-- wp:site-title {"level":0} /-->
 
 <!-- wp:paragraph -->
 <p><?php esc_html_e( 'Built with WordPress', 'blue-note' ); ?></p>

--- a/blue-note/patterns/posts.php
+++ b/blue-note/patterns/posts.php
@@ -7,10 +7,17 @@
  */
 ?>
 
-<!-- wp:query {"queryId":0,"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"displayLayout":{"type":"list","columns":3},"className":"is-style-blue-note-query-slant"} -->
-<div class="wp-block-query is-style-blue-note-query-slant">
+<!-- wp:query {"queryId":0,"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"displayLayout":{"type":"list","columns":3},"className":"is-style-blue-note-query-slant has-stacked-featured-images"} -->
+<div class="wp-block-query is-style-blue-note-query-slant has-stacked-featured-images">
 	<!-- wp:post-template {"layout":{"type":"constrained"}} -->
-		<!-- wp:post-featured-image {"isLink":true,"style":{"color":{"duotone":"var:preset|duotone|black-pink"}}} /-->
+		<!-- wp:group {"className":"stacked-featured-images","layout":{"type":"constrained"}} -->
+		<div class="wp-block-group stacked-featured-images">
+			<!-- wp:post-featured-image {"isLink":true,"style":{"color":{"duotone":"var:preset|duotone|black-pink"},"spacing":{"padding":{"top":"0","bottom":"0","left":"0","right":"0"},"margin":{"top":"0","bottom":"0","left":"0","right":"0"}}}} /-->
+			<!-- wp:post-featured-image {"isLink":true,"style":{"color":{"duotone":"var:preset|duotone|black-blue"},"spacing":{"padding":{"top":"0","bottom":"0","left":"0","right":"0"},"margin":{"top":"0","bottom":"0","left":"0","right":"0"}}}} /-->
+			<!-- wp:post-featured-image {"isLink":true,"style":{"color":{"duotone":"var:preset|duotone|black-green"},"spacing":{"padding":{"top":"0","bottom":"0","left":"0","right":"0"},"margin":{"top":"0","bottom":"0","left":"0","right":"0"}}}} /-->
+		</div>
+		<!-- /wp:group -->
+
 		<!-- wp:group {"layout":{"type":"constrained"}} -->
 		<div class="wp-block-group">
 			<!-- wp:post-title {"isLink":true,"style":{"spacing":{"margin":{"right":"0px","left":"0px","top":"40px","bottom":"16px"}}}} /-->

--- a/blue-note/patterns/posts.php
+++ b/blue-note/patterns/posts.php
@@ -10,8 +10,8 @@
 <!-- wp:query {"queryId":0,"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"displayLayout":{"type":"list","columns":3},"className":"is-style-blue-note-query-slant has-stacked-featured-images"} -->
 <div class="wp-block-query is-style-blue-note-query-slant has-stacked-featured-images">
 	<!-- wp:post-template {"layout":{"type":"constrained"}} -->
-		<!-- wp:group {"className":"stacked-featured-images","layout":{"type":"constrained"}} -->
-		<div class="wp-block-group stacked-featured-images">
+		<!-- wp:group {"className":"blue-note-stacked-featured-images","layout":{"type":"constrained"}} -->
+		<div class="wp-block-group blue-note-stacked-featured-images">
 			<!-- wp:post-featured-image {"isLink":true,"style":{"color":{"duotone":"var:preset|duotone|black-pink"},"spacing":{"padding":{"top":"0","bottom":"0","left":"0","right":"0"},"margin":{"top":"0","bottom":"0","left":"0","right":"0"}}}} /-->
 			<!-- wp:post-featured-image {"isLink":true,"style":{"color":{"duotone":"var:preset|duotone|black-blue"},"spacing":{"padding":{"top":"0","bottom":"0","left":"0","right":"0"},"margin":{"top":"0","bottom":"0","left":"0","right":"0"}}}} /-->
 			<!-- wp:post-featured-image {"isLink":true,"style":{"color":{"duotone":"var:preset|duotone|black-green"},"spacing":{"padding":{"top":"0","bottom":"0","left":"0","right":"0"},"margin":{"top":"0","bottom":"0","left":"0","right":"0"}}}} /-->

--- a/blue-note/patterns/posts.php
+++ b/blue-note/patterns/posts.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ * Title: Categories
+ * Slug: blue-note/posts
+ * Categories: uncategorized
+ * Block Types: core/query-loop
+ */
+?>
+
+<!-- wp:query {"queryId":0,"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"displayLayout":{"type":"list","columns":3},"className":"is-style-blue-note-query-slant"} -->
+<div class="wp-block-query is-style-blue-note-query-slant">
+	<!-- wp:post-template {"layout":{"type":"constrained"}} -->
+		<!-- wp:post-featured-image {"isLink":true,"style":{"color":{"duotone":"var:preset|duotone|black-pink"}}} /-->
+		<!-- wp:group {"layout":{"type":"constrained"}} -->
+		<div class="wp-block-group">
+			<!-- wp:post-title {"isLink":true,"style":{"spacing":{"margin":{"right":"0px","left":"0px","top":"40px","bottom":"16px"}}}} /-->
+			<!-- wp:post-date {"isLink":true,"style":{"spacing":{"margin":{"top":"0","bottom":"0"}}}} /-->
+			<!-- wp:spacer {"height":"70px"} -->
+			<div style="height:70px" aria-hidden="true" class="wp-block-spacer"></div>
+			<!-- /wp:spacer -->
+		</div>
+		<!-- /wp:group -->
+	<!-- /wp:post-template -->
+
+	<!-- wp:query-pagination {"layout":{"type":"flex","justifyContent":"space-between"}} -->
+	<!-- wp:query-pagination-previous /-->
+	<!-- wp:query-pagination-next /-->
+	<!-- /wp:query-pagination -->
+
+	<!-- wp:query-no-results -->
+		<!-- wp:heading -->
+		<h2 class="wp-block-heading"><?php esc_html_e( 'Sorry, but nothing matched your search terms. Please try again with some different keywords.','blue-note' ); ?></h2>
+		<!-- /wp:heading -->
+		<!-- wp:search {"label":"Search","showLabel":false,"width":75,"widthUnit":"%","buttonText":"Search"} /-->
+	<!-- /wp:query-no-results -->
+</div>
+<!-- /wp:query -->

--- a/blue-note/patterns/posts.php
+++ b/blue-note/patterns/posts.php
@@ -1,9 +1,9 @@
 <?php
 /**
- * Title: Categories
+ * Title: Post list
  * Slug: blue-note/posts
- * Categories: uncategorized
- * Block Types: core/query-loop
+ * Categories: query posts
+ * Block Types: core/query
  */
 ?>
 

--- a/blue-note/style.css
+++ b/blue-note/style.css
@@ -24,3 +24,18 @@ Kim Clow's suggested CSS for the 404 page. Refer to issue #12 in the repo for de
 	padding-top: 22px;
 	padding-bottom: 22px;
 }
+
+.stacked-featured-images {
+	display: grid;
+}
+
+.stacked-featured-images .wp-block-post-featured-image {
+	grid-area: 1 / 1 / 2 / 2;
+	z-index: 1;
+}
+
+.has-stacked-featured-images li:nth-child(3n+1) .stacked-featured-images .wp-block-post-featured-image:nth-child(1),
+.has-stacked-featured-images li:nth-child(3n+2) .stacked-featured-images .wp-block-post-featured-image:nth-child(2),
+.has-stacked-featured-images li:nth-child(3n+3) .stacked-featured-images .wp-block-post-featured-image:nth-child(3){
+	z-index: 2;
+}

--- a/blue-note/style.css
+++ b/blue-note/style.css
@@ -3,7 +3,7 @@ Theme Name: Blue Note
 Theme URI: https://github.com/WordPress/community-themes/tree/trunk/blue-note
 Author: the WordPress team
 Author URI: https://wordpress.org
-Description: 
+Description:
 Requires at least: 6.1
 Tested up to: 6.2
 Requires PHP: 7.4
@@ -25,17 +25,17 @@ Kim Clow's suggested CSS for the 404 page. Refer to issue #12 in the repo for de
 	padding-bottom: 22px;
 }
 
-.stacked-featured-images {
+.blue-note-stacked-featured-images {
 	display: grid;
 }
 
-.stacked-featured-images .wp-block-post-featured-image {
+.blue-note-stacked-featured-images .wp-block-post-featured-image {
 	grid-area: 1 / 1 / 2 / 2;
 	z-index: 1;
 }
 
-.has-stacked-featured-images li:nth-child(3n+1) .stacked-featured-images .wp-block-post-featured-image:nth-child(1),
-.has-stacked-featured-images li:nth-child(3n+2) .stacked-featured-images .wp-block-post-featured-image:nth-child(2),
-.has-stacked-featured-images li:nth-child(3n+3) .stacked-featured-images .wp-block-post-featured-image:nth-child(3){
+.has-stacked-featured-images li:nth-child(3n+1) .blue-note-stacked-featured-images .wp-block-post-featured-image:nth-child(1),
+.has-stacked-featured-images li:nth-child(3n+2) .blue-note-stacked-featured-images .wp-block-post-featured-image:nth-child(2),
+.has-stacked-featured-images li:nth-child(3n+3) .blue-note-stacked-featured-images .wp-block-post-featured-image:nth-child(3){
 	z-index: 2;
 }

--- a/blue-note/templates/archive.html
+++ b/blue-note/templates/archive.html
@@ -6,35 +6,7 @@
 
 	<!-- wp:group {"align":"full","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"center"}} -->
 	<div class="wp-block-group alignfull">
-		<!-- wp:query {"queryId":0,"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"displayLayout":{"type":"list","columns":3},"className":"is-style-blue-note-query-slant"} -->
-		<div class="wp-block-query is-style-blue-note-query-slant">
-			<!-- wp:post-template {"layout":{"type":"constrained"}} -->
-				<!-- wp:post-featured-image {"isLink":true,"style":{"color":{"duotone":"var:preset|duotone|black-pink"}}} /-->
-				<!-- wp:group {"layout":{"type":"constrained"}} -->
-				<div class="wp-block-group">
-					<!-- wp:post-title {"isLink":true,"style":{"spacing":{"margin":{"right":"0px","left":"0px","top":"40px","bottom":"16px"}}}} /-->
-					<!-- wp:post-date {"isLink":true} /-->
-					<!-- wp:spacer {"height":"70px"} -->
-					<div style="height:70px" aria-hidden="true" class="wp-block-spacer"></div>
-					<!-- /wp:spacer -->
-				</div>
-				<!-- /wp:group -->
-			<!-- /wp:post-template -->
-
-			<!-- wp:query-pagination -->
-			<!-- wp:query-pagination-previous /-->
-			<!-- wp:query-pagination-numbers /-->
-			<!-- wp:query-pagination-next /-->
-			<!-- /wp:query-pagination -->
-
-			<!-- wp:query-no-results -->
-				<!-- wp:heading -->
-				<h2 class="wp-block-heading">No Results</h2>
-				<!-- /wp:heading -->
-				<!-- wp:search {"label":"Search","showLabel":false,"width":75,"widthUnit":"%","buttonText":"Search"} /-->
-			<!-- /wp:query-no-results -->
-		</div>
-		<!-- /wp:query -->
+		<!-- wp:pattern {"slug":"blue-note/posts"} /-->
 	</div>
 	<!-- /wp:group -->
 </main>

--- a/blue-note/templates/index.html
+++ b/blue-note/templates/index.html
@@ -2,38 +2,15 @@
 
 <!-- wp:group {"tagName":"main","layout":{"type":"constrained","justifyContent":"left"}} -->
 <main class="wp-block-group">
+	<!-- wp:heading {"level":1,"style":{"spacing":{"margin":{"bottom":"100px"}}}} -->
+	<h1 class="wp-block-heading">Latest Posts</h1>
+	<!-- /wp:heading -->
 
-<!-- wp:heading {"level":1} -->
-<h1 class="wp-block-heading">Latest Posts</h1>
-<!-- /wp:heading -->
-
-	<!-- wp:query {"queryId":0,"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true}} -->
-	<div class="wp-block-query"><!-- wp:post-template -->
-		<!-- wp:post-featured-image /-->
-
-		<!-- wp:post-title {"isLink":true} /-->
-
-		<!-- wp:post-date /-->
-		<!-- /wp:post-template -->
-
-		<!-- wp:spacer -->
-		<div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
-		<!-- /wp:spacer -->
-
-		<!-- wp:query-pagination -->
-		<!-- wp:query-pagination-previous /-->
-
-		<!-- wp:query-pagination-numbers /-->
-
-		<!-- wp:query-pagination-next /-->
-		<!-- /wp:query-pagination -->
-
-		<!-- wp:query-no-results -->
-		<!-- wp:paragraph {"placeholder":"Add text or blocks that will display when a query returns no results."} -->
-		<p></p>
-		<!-- /wp:paragraph -->
-		<!-- /wp:query-no-results --></div>
-		<!-- /wp:query -->
+	<!-- wp:group {"align":"full","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"center"}} -->
+	<div class="wp-block-group alignfull">
+		<!-- wp:pattern {"slug":"blue-note/posts"} /-->
+	</div>
+	<!-- /wp:group -->
 </main>
 <!-- /wp:group -->
 

--- a/blue-note/templates/search.html
+++ b/blue-note/templates/search.html
@@ -11,34 +11,7 @@
 
 	<!-- wp:group {"align":"full","layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"center"}} -->
 	<div class="wp-block-group alignfull">
-		<!-- wp:query {"queryId":0,"query":{"perPage":3,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"displayLayout":{"type":"list","columns":3},"className":"is-style-blue-note-query-slant"} -->
-		<div class="wp-block-query is-style-blue-note-query-slant">
-			<!-- wp:post-template {"layout":{"type":"constrained"}} -->
-				<!-- wp:post-featured-image {"isLink":true,"style":{"color":{"duotone":"var:preset|duotone|black-pink"}}} /-->
-				<!-- wp:group {"layout":{"type":"constrained"}} -->
-				<div class="wp-block-group">
-					<!-- wp:post-title {"isLink":true,"style":{"spacing":{"margin":{"right":"0px","left":"0px","top":"40px","bottom":"16px"}}}} /-->
-					<!-- wp:post-date {"isLink":true} /-->
-					<!-- wp:spacer {"height":"70px"} -->
-					<div style="height:70px" aria-hidden="true" class="wp-block-spacer"></div>
-					<!-- /wp:spacer -->
-				</div>
-				<!-- /wp:group -->
-			<!-- /wp:post-template -->
-
-			<!-- wp:query-pagination -->
-			<!-- wp:query-pagination-previous /-->
-			<!-- wp:query-pagination-numbers /-->
-			<!-- wp:query-pagination-next /-->
-			<!-- /wp:query-pagination -->
-
-			<!-- wp:query-no-results -->
-			<!-- wp:paragraph -->
-			<p>Sorry, but nothing matched your search terms. Please try again with some different keywords.</p>
-			<!-- /wp:paragraph -->
-			<!-- /wp:query-no-results -->
-		</div>
-		<!-- /wp:query -->
+		<!-- wp:pattern {"slug":"blue-note/posts"} /-->
 	</div>
 	<!-- /wp:group -->
 </main>

--- a/blue-note/theme.json
+++ b/blue-note/theme.json
@@ -237,8 +237,26 @@
 			},
 			"core/post-date": {
 				"typography": {
-					"fontSize": "var(--wp--preset--font-size--medium)",
 					"fontStyle": "italic"
+				},
+				"elements": {
+					"link": {
+						"typography": {
+							"textDecoration": "none"
+						}
+					}
+				}
+			},
+			"core/post-title": {
+				"typography": {
+					"fontSize": "var(--wp--preset--font-size--extra-large)"
+				},
+				"elements": {
+					"link": {
+						"typography": {
+							"textDecoration": "none"
+						}
+					}
 				}
 			},
 			"core/query-pagination": {
@@ -256,11 +274,6 @@
 				"typography": {
 					"textDecoration": "none",
 					"lineHeight": "1"
-				}
-			},
-			"core/post-title": {
-				"typography": {
-					"fontSize": "var(--wp--preset--font-size--extra-large)"
 				}
 			},
 			"core/post-content": {
@@ -437,7 +450,8 @@
 			}
 		},
 		"typography": {
-			"fontFamily": "var(--wp--preset--font-family--old-standard-tt)"
+			"fontFamily": "var(--wp--preset--font-family--old-standard-tt)",
+			"fontSize": "var(--wp--preset--font-size--normal)"
 		}
 	},
 	"templateParts": [


### PR DESCRIPTION
This PR closes https://github.com/WordPress/community-themes/issues/9 and https://github.com/WordPress/community-themes/issues/10 and partially addresses https://github.com/WordPress/community-themes/issues/11

It's built on top of https://github.com/WordPress/community-themes/issues/60, let's merge that one first.

I don't think there's an easy way to change the duotone colors via CSS, so I'm leaving that to last, let's see if we can come up with an idea for it

I created a pattern for the query block and reused it for the index, search and archive templates. 