### PR TITLE
Blue Note: Remove label from next link

### DIFF
--- a/blue-note/patterns/post-meta-nav.php
+++ b/blue-note/patterns/post-meta-nav.php
@@ -41,7 +41,7 @@
 		<hr class="wp-block-separator has-alpha-channel-opacity"/>
 		<!-- /wp:separator -->
 		<!-- wp:post-navigation-link {"textAlign":"right","label":"<em><?php esc_html_e( 'Next', 'blue-note' ); ?></em>","linkLabel":true,"arrow":"arrow"} /-->
-		<!-- wp:post-navigation-link {"textAlign":"right","label":"","showTitle":true,"linkLabel":true,"style":{"typography":{"textTransform":"uppercase"}}} /-->
+		<!-- wp:post-navigation-link {"textAlign":"right","label":"","showTitle":true,"style":{"typography":{"textTransform":"uppercase"}}} /-->
 	</div>
 	<!-- /wp:column -->
 </div>

--- a/blue-note/templates/single.html
+++ b/blue-note/templates/single.html
@@ -6,45 +6,7 @@
 <div class="wp-block-columns"><!-- wp:column {"width":"66.66%","style":{"spacing":{"blockGap":"var:preset|spacing|60"}}} -->
 <div class="wp-block-column" style="flex-basis:66.66%"><!-- wp:post-content {"style":{"typography":{"fontSize":"22px"}}} /-->
 
-<!-- wp:group {"style":{"typography":{"fontSize":"22px"},"spacing":{"blockGap":"var:preset|spacing|30"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-<div class="wp-block-group" style="font-size:22px"><!-- wp:paragraph -->
-<p>Author: </p>
-<!-- /wp:paragraph -->
-
-<!-- wp:post-author {"showAvatar":false,"showBio":false} /-->
-
-<!-- wp:paragraph -->
-<p>/</p>
-<!-- /wp:paragraph -->
-
-<!-- wp:paragraph -->
-<p>Tags: </p>
-<!-- /wp:paragraph -->
-
-<!-- wp:post-terms {"term":"post_tag"} /--></div>
-<!-- /wp:group -->
-
-<!-- wp:columns -->
-<div class="wp-block-columns"><!-- wp:column -->
-<div class="wp-block-column"><!-- wp:separator -->
-<hr class="wp-block-separator has-alpha-channel-opacity"/>
-<!-- /wp:separator -->
-
-<!-- wp:post-navigation-link {"type":"previous","label":"<em>Previous</em>","linkLabel":true,"arrow":"arrow","style":{"typography":{"fontSize":"22px"}}} /-->
-
-<!-- wp:post-navigation-link {"type":"previous","label":"","showTitle":true,"style":{"typography":{"fontSize":"22px","textTransform":"uppercase"}}} /--></div>
-<!-- /wp:column -->
-
-<!-- wp:column -->
-<div class="wp-block-column"><!-- wp:separator -->
-<hr class="wp-block-separator has-alpha-channel-opacity"/>
-<!-- /wp:separator -->
-
-<!-- wp:post-navigation-link {"textAlign":"right","label":"<em>Next</em>","linkLabel":true,"arrow":"arrow","style":{"typography":{"fontSize":"22px"}}} /-->
-
-<!-- wp:post-navigation-link {"textAlign":"right","label":"","showTitle":true,"style":{"typography":{"fontSize":"22px","textTransform":"uppercase"}}} /--></div>
-<!-- /wp:column --></div>
-<!-- /wp:columns -->
+<!-- wp:pattern {"slug":"blue-note/post-meta-nav"} /-->
 
 <!-- wp:comments -->
 <div class="wp-block-comments"><!-- wp:group {"style":{"spacing":{"blockGap":"var:preset|spacing|60"}},"layout":{"type":"constrained"}} -->

--- a/blue-note/templates/single.html
+++ b/blue-note/templates/single.html
@@ -42,7 +42,7 @@
 
 <!-- wp:post-navigation-link {"textAlign":"right","label":"<em>Next</em>","linkLabel":true,"arrow":"arrow","style":{"typography":{"fontSize":"22px"}}} /-->
 
-<!-- wp:post-navigation-link {"textAlign":"right","label":"","showTitle":true,"linkLabel":true,"style":{"typography":{"fontSize":"22px","textTransform":"uppercase"}}} /--></div>
+<!-- wp:post-navigation-link {"textAlign":"right","label":"","showTitle":true,"style":{"typography":{"fontSize":"22px","textTransform":"uppercase"}}} /--></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns -->
 


### PR DESCRIPTION
Just removes this unnecessary label.

Before
<img width="864" alt="Screenshot 2023-07-25 at 11 02 13" src="https://github.com/WordPress/community-themes/assets/275961/748b905c-87eb-4a0a-b2cd-406ac843bb2d">

After
<img width="887" alt="Screenshot 2023-07-25 at 11 02 02" src="https://github.com/WordPress/community-themes/assets/275961/1b78f540-9252-4be9-bcd6-6f01700c7c34">
