### PR TITLE
Utilise Pattern for search form

### DIFF
--- a/blue-note/patterns/hidden-404.php
+++ b/blue-note/patterns/hidden-404.php
@@ -7,16 +7,18 @@
 ?>
 <!-- wp:group {"tagName":"main","layout":{"type":"constrained","justifyContent":"left","contentSize":"1320px"}} -->
 <main class="wp-block-group"><!-- wp:heading {"level":1} -->
-<h1 class="wp-block-heading"><?php esc_html_e( 'This page could not be found','blue-note' ); ?></h1>
+<h1 class="wp-block-heading"><?php esc_html_e( 'This page could not be found', 'blue-note' ); ?></h1>
 <!-- /wp:heading -->
 
 <!-- wp:group {"align":"full","style":{"spacing":{"padding":{"bottom":"60px","top":"59px"}}},"layout":{"type":"constrained","contentSize":"650px"}} -->
 <div class="wp-block-group alignfull" style="padding-top:59px;padding-bottom:60px"><!-- wp:paragraph {"style":{"spacing":{"padding":{"top":"0px"}},"typography":{"fontSize":"22px"}}} -->
-<p style="padding-top:0px;font-size:22px"><?php esc_html_e( 'The page you were looking for could not be found. It might have been removed, renamed, or did not exist in the first place.','blue-note' ); ?></p>
+<p style="padding-top:0px;font-size:22px"><?php esc_html_e( 'The page you were looking for could not be found. It might have been removed, renamed, or did not exist in the first place.', 'blue-note' ); ?></p>
 <!-- /wp:paragraph -->
 
 <!-- wp:group {"style":{"spacing":{"padding":{"top":"60px"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group" style="padding-top:60px"><!-- wp:search {"label":"","placeholder":"Search...","width":650,"buttonText":"Search","style":{"border":{"width":"1px"}},"borderColor":"contrast","backgroundColor":"contrast","className":"search_field"} /--></div>
+<div class="wp-block-group" style="padding-top:60px">
+<!-- wp:pattern {"slug":"blue-note/search-form"} /-->
+</div>
 <!-- /wp:group --></div>
 <!-- /wp:group --></main>
 <!-- /wp:group -->

--- a/blue-note/patterns/home.php
+++ b/blue-note/patterns/home.php
@@ -11,7 +11,7 @@
 <main class="wp-block-group" style="margin-top:100px"><!-- wp:columns {"verticalAlignment":null,"align":"wide"} -->
 <div class="wp-block-columns alignwide"><!-- wp:column {"verticalAlignment":"top","width":"65%","style":{"spacing":{"blockGap":"56px"}}} -->
 <div class="wp-block-column is-vertically-aligned-top" style="flex-basis:65%"><!-- wp:heading {"level":1,"style":{"typography":{"fontSize":"180px","fontStyle":"normal","fontWeight":"400","lineHeight":"1.10","letterSpacing":"-0.03em"}},"fontFamily":"old-standard-tt"} -->
-<h1 class="wp-block-heading has-old-standard-tt-font-family" style="font-size:180px;font-style:normal;font-weight:400;letter-spacing:-0.03em;line-height:1.10"><?php esc_html_e( 'Learn all about jazz!' , 'blue-note' ); ?></h1>
+<h1 class="wp-block-heading has-old-standard-tt-font-family" style="font-size:180px;font-style:normal;font-weight:400;letter-spacing:-0.03em;line-height:1.10"><?php esc_html_e( 'Learn all about jazz!', 'blue-note' ); ?></h1>
 <!-- /wp:heading -->
 
 <!-- wp:buttons -->
@@ -48,9 +48,13 @@
 
 		<!-- wp:query-no-results -->
 			<!-- wp:heading -->
-			<h2 class="wp-block-heading"><?php esc_html_e( 'Sorry, but nothing matched your search terms. Please try again with some different keywords.','blue-note' ); ?></h2>
+			<h2 class="wp-block-heading"><?php esc_html_e( 'Sorry, but nothing matched your search terms. Please try again with some different keywords.', 'blue-note' ); ?></h2>
 			<!-- /wp:heading -->
-			<!-- wp:search {"label":"Search","showLabel":false,"width":75,"widthUnit":"%","buttonText":"Search"} /-->
+			<!-- wp:group {"layout":{"type":"constrained","contentSize":"75%","justifyContent":"left"}} -->
+			<div class="wp-block-group">
+			<!-- wp:pattern {"slug":"blue-note/search-form"} /-->
+			</div>
+			<!-- /wp:group -->
 		<!-- /wp:query-no-results -->
 	</div>
 	<!-- /wp:query -->

--- a/blue-note/patterns/posts.php
+++ b/blue-note/patterns/posts.php
@@ -36,9 +36,13 @@
 
 	<!-- wp:query-no-results -->
 		<!-- wp:heading -->
-		<h2 class="wp-block-heading"><?php esc_html_e( 'Sorry, but nothing matched your search terms. Please try again with some different keywords.','blue-note' ); ?></h2>
+		<h2 class="wp-block-heading"><?php esc_html_e( 'Sorry, but nothing matched your search terms. Please try again with some different keywords.', 'blue-note' ); ?></h2>
 		<!-- /wp:heading -->
-		<!-- wp:search {"label":"Search","showLabel":false,"width":75,"widthUnit":"%","buttonText":"Search"} /-->
+		<!-- wp:group {"layout":{"type":"constrained","contentSize":"75%","justifyContent":"left"}} -->
+		<div class="wp-block-group">
+		<!-- wp:pattern {"slug":"blue-note/search-form"} /-->
+		</div>
+		<!-- /wp:group -->
 	<!-- /wp:query-no-results -->
 </div>
 <!-- /wp:query -->

--- a/blue-note/patterns/search-form.php
+++ b/blue-note/patterns/search-form.php
@@ -1,0 +1,9 @@
+<?php
+/**
+ * Title: Search Form
+ * Slug: blue-note/search-form
+ * Categories: uncategorized
+ * Inserter: no
+ */
+?>
+<!-- wp:search {"label":"","showLabel":false,"width":100,"widthUnit":"%","buttonText":"Search","className":"search-bar"} /-->

--- a/blue-note/templates/search.html
+++ b/blue-note/templates/search.html
@@ -3,7 +3,7 @@
 <!-- wp:group {"tagName":"main","layout":{"type":"constrained","justifyContent":"left"}} -->
 <main class="wp-block-group">
 	<!-- wp:query-title {"type":"search","fontSize":"xx-large"} /-->
-	<!-- wp:search {"label":"","showLabel":false,"width":100,"widthUnit":"%","buttonText":"Search","className":"search-bar"} /-->
+	<!-- wp:pattern {"slug":"blue-note/search-form"} /-->
 
 	<!-- wp:spacer {"height":"1px","style":{"spacing":{"margin":{"top":"50px","bottom":"50px"}}}} -->
 	<div style="margin-top:50px;margin-bottom:50px;height:1px" aria-hidden="true" class="wp-block-spacer"></div>


### PR DESCRIPTION
This PR unifies all instances of the search form into a single Pattern.

Some instances requires wrapping in a Group block to provide the original 75% constrained width.

Side note/rant: it's really not at all intuitive to set this width in the UI on the Group block.

Part of work towards https://github.com/WordPress/community-themes/issues/11