### PR TITLE
Standardise spacing between Header and Main Content across all templates

### DIFF
--- a/blue-note/parts/header.html
+++ b/blue-note/parts/header.html
@@ -1,5 +1,5 @@
-<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","right":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|60"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
-<div class="wp-block-group alignfull" style="padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--60)">
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","right":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|60"},"margin":{"bottom":"7vw"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
+<div class="wp-block-group alignfull" style="margin-bottom:7vw;padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--60)">
 	<!-- wp:site-title /-->
 	<!-- wp:navigation /-->
 </div>

--- a/blue-note/parts/header.html
+++ b/blue-note/parts/header.html
@@ -1,5 +1,5 @@
-<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","right":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|60"},"margin":{"bottom":"7vw"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
-<div class="wp-block-group alignfull" style="margin-bottom:7vw;padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--60)">
+<!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"var:preset|spacing|60","right":"var:preset|spacing|60","bottom":"var:preset|spacing|60","left":"var:preset|spacing|60"},"margin":{"bottom":"var:preset|spacing|100"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
+<div class="wp-block-group alignfull" style="margin-bottom:var(--wp--preset--spacing--100);padding-top:var(--wp--preset--spacing--60);padding-right:var(--wp--preset--spacing--60);padding-bottom:var(--wp--preset--spacing--60);padding-left:var(--wp--preset--spacing--60)">
 	<!-- wp:site-title /-->
 	<!-- wp:navigation /-->
 </div>


### PR DESCRIPTION
Many Issues mention spacing between the Header and the Main Content (often referred to as "the Heading" in the Issues).

Instead of correcting on a per template basis let's just set a bottom margin on the Group _within_ the Header part.

As this is a vertical spacing we should base on the viewport width so that it scales appropriately.

Ideally we'd be able to clamp this to a min-max but I don't think that's possible...it is?


Part of https://github.com/WordPress/community-themes/issues/11