### PR TITLE
Blue Note: Vertically center the post title and date

### DIFF
--- a/blue-note/parts/header-large.html
+++ b/blue-note/parts/header-large.html
@@ -7,13 +7,13 @@
 <!-- /wp:group -->
 
 <!-- wp:group {"align":"full","style":{"spacing":{"blockGap":"0"}},"backgroundColor":"contrast","textColor":"base","layout":{"type":"default"}} -->
-<div class="wp-block-group alignfull has-base-color has-contrast-background-color has-text-color has-background"><!-- wp:columns {"verticalAlignment":"top","align":"full","style":{"spacing":{"blockGap":{"top":"var:preset|spacing|50","left":"var:preset|spacing|50"}}}} -->
-<div class="wp-block-columns alignfull are-vertically-aligned-top"><!-- wp:column {"verticalAlignment":"top","layout":{"type":"default"}} -->
+<div class="wp-block-group alignfull has-base-color has-contrast-background-color has-text-color has-background"><!-- wp:columns {"verticalAlignment":null,"align":"full","style":{"spacing":{"blockGap":{"top":"var:preset|spacing|50","left":"var:preset|spacing|50"}}}} -->
+<div class="wp-block-columns alignfull"><!-- wp:column {"verticalAlignment":"top","layout":{"type":"default"}} -->
 <div class="wp-block-column is-vertically-aligned-top"><!-- wp:post-featured-image /--></div>
 <!-- /wp:column -->
 
-<!-- wp:column {"verticalAlignment":"top","style":{"spacing":{"padding":{"top":"var:preset|spacing|70","right":"var:preset|spacing|50","bottom":"var:preset|spacing|70","left":"var:preset|spacing|50"}}}} -->
-<div class="wp-block-column is-vertically-aligned-top" style="padding-top:var(--wp--preset--spacing--70);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--70);padding-left:var(--wp--preset--spacing--50)"><!-- wp:post-date {"style":{"typography":{"fontSize":"22px"}}} /-->
+<!-- wp:column {"verticalAlignment":"center","style":{"spacing":{"padding":{"top":"var:preset|spacing|70","right":"var:preset|spacing|50","bottom":"var:preset|spacing|70","left":"var:preset|spacing|50"}}}} -->
+<div class="wp-block-column is-vertically-aligned-center" style="padding-top:var(--wp--preset--spacing--70);padding-right:var(--wp--preset--spacing--50);padding-bottom:var(--wp--preset--spacing--70);padding-left:var(--wp--preset--spacing--50)"><!-- wp:post-date {"style":{"typography":{"fontSize":"22px"}}} /-->
 
 <!-- wp:post-title {"level":1,"style":{"typography":{"fontSize":"95px"}}} /--></div>
 <!-- /wp:column --></div>


### PR DESCRIPTION
According to the figma the post tile and date should be vertically aligned:

<img width="1070" alt="Screenshot 2023-07-26 at 09 36 06" src="https://github.com/WordPress/community-themes/assets/275961/f82c38e6-80fe-46cd-a1a8-3e7c87d69d04">
