### PR TITLE
Atlas: Added block styles for angled versions of starscape and cover block

### DIFF
--- a/atlas/functions.php
+++ b/atlas/functions.php
@@ -1,0 +1,46 @@
+<?php
+
+/**
+ * Register block styles.
+ */
+
+ if ( ! function_exists( 'atlas_block_styles' ) ) :
+	/**
+	 * Register custom block styles
+	 *
+	 * @since Twenty Twenty-Four 1.0
+	 * @return void
+	 */
+	function atlas_block_styles() {
+
+		register_block_style(
+			'a8c/starscape',
+			array(
+				'name'         => 'angled',
+				'label'        => __( 'Angled', 'atlas' ),
+				'inline_style' => "
+				.is-style-angled {
+					clip-path: polygon(0 0,100% 0,100% 90%,50% 100%,0 90%);
+					overflow: hidden;
+				}
+				",
+			)
+		);
+
+		register_block_style(
+			'core/cover',
+			array(
+				'name'         => 'angled',
+				'label'        => __( 'Angled', 'atlas' ),
+				'inline_style' => "
+				.is-style-angled {
+					clip-path: polygon(0 0,100% 0,100% 90%,50% 100%,0 90%);
+					overflow: hidden;
+				}
+				",
+			)
+		);
+	}
+endif;
+
+add_action( 'init', 'atlas_block_styles' );


### PR DESCRIPTION
Adds block styles for atlas to create an angled shape on cover blocks and starscape blocks

<img width="1529" alt="Screenshot 2023-12-21 at 19 00 00" src="https://github.com/WordPress/community-themes/assets/3593343/9a459545-fdb1-49b8-b11a-28a839f67938">
