### PR TITLE
Atlas: Update header

### DIFF
--- a/atlas/parts/header.html
+++ b/atlas/parts/header.html
@@ -1,10 +1,27 @@
 <!-- wp:group {"layout":{"type":"constrained"}} -->
-<div class="wp-block-group">
-	<!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"var:preset|spacing|40"}}},"layout":{"type":"flex","justifyContent":"space-between"}} -->
-	<div class="wp-block-group alignwide" style="padding-bottom:var(--wp--preset--spacing--40)">
-		<!-- wp:site-title {"level":0} /-->
-		<!-- wp:navigation {"layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"right"}} /-->
-	</div>
-	<!-- /wp:group -->
-</div>
+<div class="wp-block-group"><!-- wp:group {"align":"wide","layout":{"type":"flex","flexWrap":"wrap","justifyContent":"space-between"}} -->
+<div class="wp-block-group alignwide"><!-- wp:group {"layout":{"type":"flex","justifyContent":"left","flexWrap":"wrap"}} -->
+<div class="wp-block-group"><!-- wp:site-title {"level":0} /-->
+
+<!-- wp:navigation {"ref":973,"icon":"menu","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"left"}} /--></div>
+<!-- /wp:group -->
+
+<!-- wp:group {"style":{"layout":{"selfStretch":"fill","flexSize":null}},"layout":{"type":"default"}} -->
+<div class="wp-block-group"><!-- wp:social-links {"iconColor":"contrast","iconColorValue":"#e6e6dc","className":"is-style-logos-only","layout":{"type":"flex","justifyContent":"right","flexWrap":"nowrap"}} -->
+<ul class="wp-block-social-links has-icon-color is-style-logos-only"><!-- wp:social-link {"url":"wordpress.org","service":"wordpress"} /-->
+
+<!-- wp:social-link {"url":"github.com/WordPress","service":"github"} /-->
+
+<!-- wp:social-link {"url":"https://www.facebook.com/WordPress/","service":"facebook"} /-->
+
+<!-- wp:social-link {"url":"https://www.facebook.com/WordPress/","service":"x"} /-->
+
+<!-- wp:social-link {"url":"https://www.linkedin.com/company/wordpress","service":"linkedin"} /-->
+
+<!-- wp:social-link {"url":"https://youtube.com/WordPress","service":"youtube"} /-->
+
+<!-- wp:social-link {"url":"https://instagram.com/WordPress","service":"instagram"} /--></ul>
+<!-- /wp:social-links --></div>
+<!-- /wp:group --></div>
+<!-- /wp:group --></div>
 <!-- /wp:group -->

--- a/atlas/parts/header.html
+++ b/atlas/parts/header.html
@@ -3,7 +3,7 @@
 <div class="wp-block-group alignwide"><!-- wp:group {"layout":{"type":"flex","justifyContent":"left","flexWrap":"wrap"}} -->
 <div class="wp-block-group"><!-- wp:site-title {"level":0} /-->
 
-<!-- wp:navigation {"ref":973,"icon":"menu","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"left"}} /--></div>
+<!-- wp:navigation {"icon":"menu","layout":{"type":"flex","setCascadingProperties":true,"justifyContent":"left"}} /--></div>
 <!-- /wp:group -->
 
 <!-- wp:group {"style":{"layout":{"selfStretch":"fill","flexSize":null}},"layout":{"type":"default"}} -->

--- a/atlas/parts/header.html
+++ b/atlas/parts/header.html
@@ -12,15 +12,7 @@
 
 <!-- wp:social-link {"url":"github.com/WordPress","service":"github"} /-->
 
-<!-- wp:social-link {"url":"https://www.facebook.com/WordPress/","service":"facebook"} /-->
-
-<!-- wp:social-link {"url":"https://www.facebook.com/WordPress/","service":"x"} /-->
-
-<!-- wp:social-link {"url":"https://www.linkedin.com/company/wordpress","service":"linkedin"} /-->
-
-<!-- wp:social-link {"url":"https://youtube.com/WordPress","service":"youtube"} /-->
-
-<!-- wp:social-link {"url":"https://instagram.com/WordPress","service":"instagram"} /--></ul>
+<!-- wp:social-link {"url":"https://www.linkedin.com/company/wordpress","service":"linkedin"} /--></ul>
 <!-- /wp:social-links --></div>
 <!-- /wp:group --></div>
 <!-- /wp:group --></div>

--- a/atlas/theme.json
+++ b/atlas/theme.json
@@ -110,7 +110,7 @@
 		},
 		"layout": {
 			"contentSize": "640px",
-			"wideSize": "880px"
+			"wideSize": "1344px"
 		}
 	},
 	"styles": {
@@ -295,9 +295,9 @@
 		"spacing": {
 			"blockGap": "2rem",
 			"padding": {
-				"top": "0px",
+				"top": "var(--wp--preset--spacing--30)",
 				"right": "var(--wp--preset--spacing--30)",
-				"bottom": "var(--wp--preset--spacing--40)",
+				"bottom": "var(--wp--preset--spacing--30)",
 				"left": "var(--wp--preset--spacing--30)"
 			}
 		},


### PR DESCRIPTION
This updates the Atlas header to add social icons and move the navigation to the left:

<img width="598" alt="Screenshot 2023-12-22 at 11 58 22" src="https://github.com/WordPress/community-themes/assets/275961/69ffae13-4400-4630-a316-b285aa9b7049">
<img width="1512" alt="Screenshot 2023-12-22 at 11 58 09" src="https://github.com/WordPress/community-themes/assets/275961/0f020a53-f939-47c6-8875-ad3e4f38fe20">
