### PR TITLE
Adding Poetry: 404 and search templates

### DIFF
--- a/poetry/parts/secondary-header.html
+++ b/poetry/parts/secondary-header.html
@@ -1,4 +1,4 @@
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"32px","bottom":"32px"}}},"layout":{"type":"constrained"}} -->
+<!-- wp:group {"tagName":"header","style":{"spacing":{"padding":{"top":"32px","bottom":"32px"}}},"layout":{"type":"constrained"}} -->
     <div class="wp-block-group" style="padding-top:32px;padding-bottom:32px">
         <!-- wp:group {"style":{"spacing":{"blockGap":"64px"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
         <div class="wp-block-group">
@@ -7,8 +7,9 @@
                 <!-- wp:site-title {"level":0,"isLink":false,"style":{"typography":{"fontSize":"24px","fontStyle":"normal","fontWeight":"600"}},"textColor":"custom-text"} /-->
     
                 <!-- wp:group {"style":{"spacing":{"blockGap":"48px"}},"layout":{"type":"flex","orientation":"vertical"}} -->
-                <div class="wp-block-group"><!-- wp:heading {"level":1} -->
-                    <h1 class="wp-block-heading">Alas, <br>where words once wandered</h1>
+                <div class="wp-block-group">
+                    <!-- wp:heading {"level":1,"style":{"typography":{"fontSize":"58px"}}} -->
+                    <h1 class="wp-block-heading" style="font-size:58px">Alas, where words once wandered</h1>
                     <!-- /wp:heading -->
                 </div>
                 <!-- /wp:group -->
@@ -16,14 +17,5 @@
             <!-- /wp:group -->
         </div>
         <!-- /wp:group -->
-    </div>
-    <!-- /wp:group -->
-    
-    <!-- wp:group {"style":{"spacing":{"padding":{"top":"32px","bottom":"64px"}}},"layout":{"type":"constrained"}} -->
-    <div class="wp-block-group" style="padding-top:32px;padding-bottom:64px"><!-- wp:heading {"level":5} -->
-        <h5 class="wp-block-heading">It looks like nothing was found at this location. Try a search.</h5>
-        <!-- /wp:heading -->
-    
-        <!-- wp:search {"label":"Search...","buttonText":"Search","buttonUseIcon":true} /-->
     </div>
     <!-- /wp:group -->

--- a/poetry/templates/404.html
+++ b/poetry/templates/404.html
@@ -1,0 +1,29 @@
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"32px","bottom":"32px"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group" style="padding-top:32px;padding-bottom:32px">
+    <!-- wp:group {"style":{"spacing":{"blockGap":"64px"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+    <div class="wp-block-group">
+        <!-- wp:group {"style":{"spacing":{"blockGap":"88px"}},"layout":{"type":"flex","orientation":"vertical"}} -->
+        <div class="wp-block-group">
+            <!-- wp:site-title {"level":0,"isLink":false,"style":{"typography":{"fontSize":"24px","fontStyle":"normal","fontWeight":"600"}},"textColor":"custom-text"} /-->
+
+            <!-- wp:group {"style":{"spacing":{"blockGap":"48px"}},"layout":{"type":"flex","orientation":"vertical"}} -->
+            <div class="wp-block-group"><!-- wp:heading {"level":1} -->
+                <h1 class="wp-block-heading">Alas, <br>where words once wandered</h1>
+                <!-- /wp:heading -->
+            </div>
+            <!-- /wp:group -->
+        </div>
+        <!-- /wp:group -->
+    </div>
+    <!-- /wp:group -->
+</div>
+<!-- /wp:group -->
+
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"32px","bottom":"64px"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group" style="padding-top:32px;padding-bottom:64px"><!-- wp:heading {"level":5} -->
+    <h5 class="wp-block-heading">It looks like nothing was found at this location. Try a search.</h5>
+    <!-- /wp:heading -->
+
+    <!-- wp:search {"label":"Search...","buttonText":"Search","buttonUseIcon":true} /-->
+</div>
+<!-- /wp:group -->

--- a/poetry/templates/search.html
+++ b/poetry/templates/search.html
@@ -22,8 +22,8 @@
 <div style="height:50px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:group {"tagName":"main","layout":{"contentSize":null,"type":"constrained"}} -->
-<main class="wp-block-group">
+<!-- wp:group {"tagName":"main","backgroundColor":"custom-background-light","layout":{"contentSize":null,"type":"constrained"}} -->
+<main class="wp-block-group has-custom-background-light-background-color has-background">
     <!-- wp:query {"queryId":0,"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true,"taxQuery":null,"parents":[]},"tagName":"main","layout":{"contentSize":null,"type":"constrained"}} -->
     <main class="wp-block-query"><!-- wp:group {"backgroundColor":"custom-background-light"} -->
         <div class="wp-block-group has-custom-background-light-background-color has-background">

--- a/poetry/templates/search.html
+++ b/poetry/templates/search.html
@@ -1,0 +1,77 @@
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"32px","bottom":"64px"}}},"layout":{"type":"constrained"}} -->
+<div class="wp-block-group" style="padding-top:32px;padding-bottom:64px">
+    <!-- wp:group {"style":{"spacing":{"blockGap":"64px"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+    <div class="wp-block-group">
+        <!-- wp:group {"style":{"spacing":{"blockGap":"88px"}},"layout":{"type":"flex","orientation":"vertical"}} -->
+        <div class="wp-block-group">
+            <!-- wp:site-title {"level":0,"isLink":false,"style":{"typography":{"fontSize":"24px","fontStyle":"normal","fontWeight":"600"}},"textColor":"custom-text"} /-->
+
+            <!-- wp:group {"style":{"spacing":{"blockGap":"48px"}},"layout":{"type":"flex","orientation":"vertical"}} -->
+            <div class="wp-block-group">
+                <!-- wp:query-title {"type":"search","align":"wide","style":{"typography":{"lineHeight":"1","fontSize":"90px"},"spacing":{"padding":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|10"}}}} /-->
+            </div>
+            <!-- /wp:group -->
+        </div>
+        <!-- /wp:group -->
+    </div>
+    <!-- /wp:group -->
+</div>
+<!-- /wp:group -->
+
+<!-- wp:spacer {"height":"50px"} -->
+<div style="height:50px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:group {"tagName":"main","layout":{"contentSize":null,"type":"constrained"}} -->
+<main class="wp-block-group">
+    <!-- wp:query {"queryId":0,"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true,"taxQuery":null,"parents":[]},"tagName":"main","layout":{"contentSize":null,"type":"constrained"}} -->
+    <main class="wp-block-query"><!-- wp:group {"backgroundColor":"custom-background-light"} -->
+        <div class="wp-block-group has-custom-background-light-background-color has-background">
+            <!-- wp:post-template {"layout":{"type":"default"}} -->
+            <!-- wp:group {"layout":{"type":"default"}} -->
+            <div class="wp-block-group">
+                <!-- wp:group {"style":{"spacing":{"padding":{"top":"96px","right":"0","bottom":"96px","left":"0"},"blockGap":"40px"}},"layout":{"type":"flex","flexWrap":"nowrap","orientation":"horizontal","verticalAlignment":"top","justifyContent":"center"}} -->
+                <div class="wp-block-group" style="padding-top:96px;padding-right:0;padding-bottom:96px;padding-left:0">
+                    <!-- wp:group {"style":{"spacing":{"padding":{"top":"96px"}}},"layout":{"type":"default"}} -->
+                    <div class="wp-block-group" style="padding-top:96px"><!-- wp:post-date /--></div>
+                    <!-- /wp:group -->
+
+                    <!-- wp:group {"style":{"spacing":{"padding":{"right":"56px","left":"56px"},"blockGap":"32px"},"border":{"left":{"width":"2px"}}},"layout":{"type":"flex","orientation":"vertical","flexWrap":"nowrap"}} -->
+                    <div class="wp-block-group" style="border-left-width:2px;padding-right:56px;padding-left:56px">
+                        <!-- wp:image {"id":15,"width":"56px","height":"56px","sizeSlug":"full","linkDestination":"none"} -->
+                        <figure class="wp-block-image size-full is-resized"><img
+                                src="https://susty.lndo.site/wp-content/themes/poetry/assets/images/feather-small.png"
+                                alt="" class="wp-image-15" style="width:56px;height:56px" /></figure>
+                        <!-- /wp:image -->
+
+                        <!-- wp:post-title {"style":{"spacing":{"padding":{"right":"24%"}}}} /-->
+
+                        <!-- wp:group {"style":{"spacing":{"blockGap":"8px"},"elements":{"link":{"color":{"text":"var:preset|color|vivid-red"}}}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+                        <div class="wp-block-group has-link-color"><!-- wp:paragraph {"textColor":"custom-contrast"} -->
+                            <p class="has-custom-contrast-color has-text-color">By</p>
+                            <!-- /wp:paragraph -->
+
+                            <!-- wp:post-author {"showAvatar":false,"showBio":false,"textColor":"custom-contrast"} /-->
+                        </div>
+                        <!-- /wp:group -->
+
+                        <!-- wp:post-content /-->
+                    </div>
+                    <!-- /wp:group -->
+                </div>
+                <!-- /wp:group -->
+
+                <!-- wp:spacer {"height":"40px"} -->
+                <div style="height:40px" aria-hidden="true" class="wp-block-spacer"></div>
+                <!-- /wp:spacer -->
+            </div>
+            <!-- /wp:group -->
+            <!-- /wp:post-template -->
+        </div>
+        <!-- /wp:group -->
+    </main>
+    <!-- /wp:query -->
+</main>
+<!-- /wp:group -->
+
+<!-- wp:template-part {"slug":"footer","theme":"poetry","tagName":"footer","area":"footer"} /-->


### PR DESCRIPTION
https://github.com/WordPress/community-themes/issues/130

## 404

![Screenshot-2024-03-07 --13 51 45](https://github.com/WordPress/community-themes/assets/10615884/00898cca-2e99-4ca0-aec7-7ce2a964b1e1)

I gave it a poetry-esque 404 message.

## Search

![Screenshot-2024-03-07 --14 07 17](https://github.com/WordPress/community-themes/assets/10615884/82d6298c-921d-46b1-a716-f18999b9ce27)

The loop results uses the same style as the index page, but looks like this needs some adjustment to the column/group widths to stop the date wrapping?
