### PR TITLE
Adds license.txt to poetry/assets

### DIFF
--- a/poetry/assets/license.txt
+++ b/poetry/assets/license.txt
@@ -1,0 +1,12 @@
+Copyright (c) 2016 The Inter Project Authors (https://github.com/rsms/inter)
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is copied below, and is also available with a FAQ at:
+http://scripts.sil.org/OFL
+
+Copyright (c) 2014 The Indian Type Foundry (https://github.com/itfoundry/rozhaone)
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is copied below, and is also available with a FAQ at:
+http://scripts.sil.org/OFL
+
+
+


### PR DESCRIPTION
Related issue - #136

I couldn't find any license info on the images, though.