### PR TITLE
Preview Action: Use pull_request_target to avoid token restriction

### DIFF
--- a/.github/workflows/preview-theme.yml
+++ b/.github/workflows/preview-theme.yml
@@ -1,7 +1,8 @@
 name: Preview Theme Changes
 
 on:
-  pull_request:
+  pull_request_target:
+    types: [opened, synchronize]
 
 jobs:
   check-for-changes-to-themes:
@@ -9,12 +10,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Retrieved Theme Changes
         id: check-for-changes
         run: |
           # Retrieve list of all changed files
-          git fetch origin trunk:trunk
+          git fetch origin
           changed_files=$(git diff --name-only HEAD origin/trunk)
           
           # Loop through changed files and identify parent directories
@@ -34,12 +37,13 @@ jobs:
           if [[ ${#unique_dirs[@]} -eq 0 ]]; then
               echo "No theme changes detected"
               echo "HAS_THEME_CHANGES=false" >> $GITHUB_OUTPUT
-              exit 0 # Use exit code 0 for successful completion
+              exit 0
           fi
           # Output list of theme slugs with changes
           echo "HAS_THEME_CHANGES=true" >> $GITHUB_OUTPUT
           echo "CHANGED_THEMES=$(echo ${unique_dirs[@]})" >> $GITHUB_ENV
           echo "Theme directories with changes: $CHANGED_THEMES"
+
       - name: Add Preview Links comment
         id: comment-on-pr
         if: ${{ steps.check-for-changes.outputs.HAS_THEME_CHANGES == 'true' }}
@@ -49,6 +53,7 @@ jobs:
           script: |
             const createPreviewLinks = require('.github/scripts/create-preview-links');
             createPreviewLinks(github, context, process.env.CHANGED_THEMES);
+
       - name: Remove comment if no changes are detected
         if: ${{ steps.check-for-changes.outputs.HAS_THEME_CHANGES == 'false' }}
         uses: actions/github-script@v7


### PR DESCRIPTION
Due to restrictions imposed to the `GH_TOKEN` when forks are created from forks when workflows are triggered by the `pull_request` event, I'm switching the execution to be done on `pull_request_trigger`, which lifts said restrictions.

Docs: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target

    This event runs in the context of the base of the pull request, rather
    than in the context of the merge commit, as the pull_request event does.
    This prevents execution of unsafe code from the head of the pull request
    that could alter your repository or steal any secrets you use in your
    workflow. This event allows your workflow to do things like label or
    comment on pull requests from forks. Avoid using this event if you need
    to build or run code from the pull request.