### PR TITLE
Revert changes in preview-themes workflow

### DIFF
--- a/.github/workflows/preview-theme.yml
+++ b/.github/workflows/preview-theme.yml
@@ -1,8 +1,7 @@
 name: Preview Theme Changes
 
 on:
-  pull_request_target:
-    types: [opened, synchronize]
+  pull_request:
 
 jobs:
   check-for-changes-to-themes:
@@ -10,14 +9,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Retrieved Theme Changes
         id: check-for-changes
         run: |
           # Retrieve list of all changed files
-          git fetch origin
+          git fetch origin trunk:trunk
           changed_files=$(git diff --name-only HEAD origin/trunk)
           
           # Loop through changed files and identify parent directories
@@ -37,13 +34,12 @@ jobs:
           if [[ ${#unique_dirs[@]} -eq 0 ]]; then
               echo "No theme changes detected"
               echo "HAS_THEME_CHANGES=false" >> $GITHUB_OUTPUT
-              exit 0
+              exit 0 # Use exit code 0 for successful completion
           fi
           # Output list of theme slugs with changes
           echo "HAS_THEME_CHANGES=true" >> $GITHUB_OUTPUT
           echo "CHANGED_THEMES=$(echo ${unique_dirs[@]})" >> $GITHUB_ENV
           echo "Theme directories with changes: $CHANGED_THEMES"
-
       - name: Add Preview Links comment
         id: comment-on-pr
         if: ${{ steps.check-for-changes.outputs.HAS_THEME_CHANGES == 'true' }}
@@ -53,7 +49,6 @@ jobs:
           script: |
             const createPreviewLinks = require('.github/scripts/create-preview-links');
             createPreviewLinks(github, context, process.env.CHANGED_THEMES);
-
       - name: Remove comment if no changes are detected
         if: ${{ steps.check-for-changes.outputs.HAS_THEME_CHANGES == 'false' }}
         uses: actions/github-script@v7


### PR DESCRIPTION
Reverts back to using `pull_request` as the event trigger for the preview themes workflow.