### PR TITLE
Update playgrounds link to include github export preconfig

### DIFF
--- a/.github/scripts/create-preview-links.js
+++ b/.github/scripts/create-preview-links.js
@@ -76,7 +76,7 @@ function createPlaygroundPreconfiguredLink(themeName = '', blueprint = '', exist
 
 	if ( existingPr ) {
 		searchParams.set('ghexport-pr-action', 'update');
-		searchParams.set('ghexport-pr-number', existingPr); // It's not supported yet - see PR WordPress/wordpress-playground#1465
+		searchParams.set('ghexport-pr-number', existingPr); // See: WordPress/wordpress-playground#1465
 	}
 
 	url.search = searchParams.toString();

--- a/.github/scripts/create-preview-links.js
+++ b/.github/scripts/create-preview-links.js
@@ -100,7 +100,7 @@ async function createPreviewLinksComment(github, context, changedThemeSlugs) {
 			const parentThemeName = getParentThemeName(themeSlug);
 			const themeName = getThemeName( themeSlug );
 			const blueprint = createBlueprint( themeSlug, context.payload.pull_request.head.ref );
-			const playgroundUrl = createPlaygroundPreconfiguredLink( themeName, blueprint, context.payload.pull_request.number );
+			const playgroundUrl = createPlaygroundPreconfiguredLink( themeSlug, blueprint, context.payload.pull_request.number );
 
 			const note = parentThemeName
 				? ` (child theme of **${parentThemeName}**)`

--- a/.github/scripts/create-preview-links.js
+++ b/.github/scripts/create-preview-links.js
@@ -65,7 +65,7 @@ function getParentThemeName(themeSlug) {
 		: '';
 }
 
-async function createPlaygroundPreconfiguredLink(themeName = '', blueprint = '', existingPr = false) {
+function createPlaygroundPreconfiguredLink(themeName = '', blueprint = '', existingPr = false) {
 	const url = new URL('https://playground.wordpress.net/');
 	const searchParams = new URLSearchParams();
 

--- a/.github/scripts/create-preview-links.js
+++ b/.github/scripts/create-preview-links.js
@@ -70,7 +70,7 @@ function createPlaygroundPreconfiguredLink(themeName = '', blueprint = '', exist
 	const searchParams = new URLSearchParams();
 
 	searchParams.set('storage', 'browser'); // We need to have the storage to be able to create/update the PR
-	searchParams.set('ghexport-repo-url', encodeURIComponent('https://github.com/WordPress/community-themes'));
+	searchParams.set('ghexport-repo-url', 'https://github.com/WordPress/community-themes');
 	searchParams.set('ghexport-content-type', 'theme');
 	searchParams.set('ghexport-theme', themeName);
 

--- a/.github/scripts/create-preview-links.js
+++ b/.github/scripts/create-preview-links.js
@@ -66,7 +66,7 @@ function getParentThemeName(themeSlug) {
 }
 
 async function createPlaygroundPreconfiguredLink(themeName = '', blueprint = '', existingPr = false) {
-	const url = new URL('https://wordpress.org/playground/');
+	const url = new URL('https://playground.wordpress.net/');
 	const searchParams = new URLSearchParams();
 
 	searchParams.set('storage', 'browser'); // We need to have the storage to be able to create/update the PR
@@ -76,7 +76,7 @@ async function createPlaygroundPreconfiguredLink(themeName = '', blueprint = '',
 
 	if ( existingPr ) {
 		searchParams.set('ghexport-pr-action', 'update');
-		searchParams.set('ghexport-pr-number', existingPr); // It's not supported yet - see PR WordPress/wordpress-playground# TODO
+		searchParams.set('ghexport-pr-number', existingPr); // It's not supported yet - see PR WordPress/wordpress-playground#1465
 	}
 
 	url.search = searchParams.toString();

--- a/README.md
+++ b/README.md
@@ -12,15 +12,30 @@ The aim of this repo is to submit the block themes to the WordPress.org themes d
 
 To get started with development you have a couple of options. You can set up a local environment or you can use the new [WordPress Playground](https://developer.wordpress.org/playground/) and build your theme online without needing to install anything at all on your machine.
 
-**If you prefer to use the Playground:**
+#### If you prefer to use the Playground:
+
+> Warning: The Playground has a few limitations and you won't be able to add new fonts to your theme using it.
+
+##### Option #1 (manual):
 
 1. Visit the [Playground](https://playground.wordpress.net/?theme=twentytwentythree&plugin=gutenberg&plugin=create-block-theme&url=/wp-admin/index.php). This instance has the Create Block Theme plugin installed.
 1. Go to Appearance/Site Editor and build your theme!
 1. Export it using the Create Block Theme plugin under Appearance/Create Block Theme
 
-The Playground has a few limitations and you won't be able to add new fonts to your theme using it.
+##### Option #2 (direct link):
 
-**If you want to work locally:**
+You can boot up the Playground with the selected theme by clicking one of the links below:
+
+- [Poetry](https://playground.wordpress.net/?storage=browser&ghexport-repo-url=https://github.com/WordPress/community-themes&ghexport-content-type=theme&ghexport-theme=poetry#%7B%22steps%22:%5B%7B%22step%22:%22login%22,%22username%22:%22admin%22,%22password%22:%22password%22%7D,%7B%22step%22:%22installTheme%22,%22themeZipFile%22:%7B%22resource%22:%22url%22,%22url%22:%22https://github-proxy.com/proxy.php?action=partial&repo=Wordpress/community-themes&directory=poetry&branch=trunk%22%7D%7D,%7B%22step%22:%22activateTheme%22,%22themeFolderName%22:%22poetry%22%7D%5D%7D)
+- [Archivist](https://playground.wordpress.net/?storage=browser&ghexport-repo-url=https://github.com/WordPress/community-themes&ghexport-content-type=theme&ghexport-theme=archivist#%7B%22steps%22:%5B%7B%22step%22:%22login%22,%22username%22:%22admin%22,%22password%22:%22password%22%7D,%7B%22step%22:%22installTheme%22,%22themeZipFile%22:%7B%22resource%22:%22url%22,%22url%22:%22https://github-proxy.com/proxy.php?action=partial&repo=Wordpress/community-themes&directory=archivist&branch=trunk%22%7D%7D,%7B%22step%22:%22activateTheme%22,%22themeFolderName%22:%22archivist%22%7D%5D%7D)
+- [Atlas](https://playground.wordpress.net/?storage=browser&ghexport-repo-url=https://github.com/WordPress/community-themes&ghexport-content-type=theme&ghexport-theme=atlas#%7B%22steps%22:%5B%7B%22step%22:%22login%22,%22username%22:%22admin%22,%22password%22:%22password%22%7D,%7B%22step%22:%22installTheme%22,%22themeZipFile%22:%7B%22resource%22:%22url%22,%22url%22:%22https://github-proxy.com/proxy.php?action=partial&repo=Wordpress/community-themes&directory=atlas&branch=trunk%22%7D%7D,%7B%22step%22:%22activateTheme%22,%22themeFolderName%22:%22atlas%22%7D%5D%7D)
+- [Blue Note](https://playground.wordpress.net/?storage=browser&ghexport-repo-url=https://github.com/WordPress/community-themes&ghexport-content-type=theme&ghexport-theme=blue-note#%7B%22steps%22:%5B%7B%22step%22:%22login%22,%22username%22:%22admin%22,%22password%22:%22password%22%7D,%7B%22step%22:%22installTheme%22,%22themeZipFile%22:%7B%22resource%22:%22url%22,%22url%22:%22https://github-proxy.com/proxy.php?action=partial&repo=Wordpress/community-themes&directory=blue-note&branch=trunk%22%7D%7D,%7B%22step%22:%22activateTheme%22,%22themeFolderName%22:%22blue-note%22%7D%5D%7D)
+- [Purr](https://playground.wordpress.net/?storage=browser&ghexport-repo-url=https://github.com/WordPress/community-themes&ghexport-content-type=theme&ghexport-theme=purr#%7B%22steps%22:%5B%7B%22step%22:%22login%22,%22username%22:%22admin%22,%22password%22:%22password%22%7D,%7B%22step%22:%22installTheme%22,%22themeZipFile%22:%7B%22resource%22:%22url%22,%22url%22:%22https://github-proxy.com/proxy.php?action=partial&repo=Wordpress/community-themes&directory=purr&branch=trunk%22%7D%7D,%7B%22step%22:%22activateTheme%22,%22themeFolderName%22:%22purr%22%7D%5D%7D)
+- [Stacks](https://playground.wordpress.net/?storage=browser&ghexport-repo-url=https://github.com/WordPress/community-themes&ghexport-content-type=theme&ghexport-theme=stacks#%7B%22steps%22:%5B%7B%22step%22:%22login%22,%22username%22:%22admin%22,%22password%22:%22password%22%7D,%7B%22step%22:%22installTheme%22,%22themeZipFile%22:%7B%22resource%22:%22url%22,%22url%22:%22https://github-proxy.com/proxy.php?action=partial&repo=Wordpress/community-themes&directory=stacks&branch=trunk%22%7D%7D,%7B%22step%22:%22activateTheme%22,%22themeFolderName%22:%22stacks%22%7D%5D%7D)
+- [Term](https://playground.wordpress.net/?storage=browser&ghexport-repo-url=https://github.com/WordPress/community-themes&ghexport-content-type=theme&ghexport-theme=term#%7B%22steps%22:%5B%7B%22step%22:%22login%22,%22username%22:%22admin%22,%22password%22:%22password%22%7D,%7B%22step%22:%22installTheme%22,%22themeZipFile%22:%7B%22resource%22:%22url%22,%22url%22:%22https://github-proxy.com/proxy.php?action=partial&repo=Wordpress/community-themes&directory=term&branch=trunk%22%7D%7D,%7B%22step%22:%22activateTheme%22,%22themeFolderName%22:%22term%22%7D%5D%7D)
+- [TT1 Blocks](https://playground.wordpress.net/?storage=browser&ghexport-repo-url=https://github.com/WordPress/community-themes&ghexport-content-type=theme&ghexport-theme=tt1-blocks#%7B%22steps%22:%5B%7B%22step%22:%22login%22,%22username%22:%22admin%22,%22password%22:%22password%22%7D,%7B%22step%22:%22installTheme%22,%22themeZipFile%22:%7B%22resource%22:%22url%22,%22url%22:%22https://github-proxy.com/proxy.php?action=partial&repo=Wordpress/community-themes&directory=tt1-blocks&branch=trunk%22%7D%7D,%7B%22step%22:%22activateTheme%22,%22themeFolderName%22:%22tt1-blocks%22%7D%5D%7D)
+
+#### If you want to work locally:
 
 1. Set up a WordPress instance, here is a [handy guide to install WordPress locally](https://wordpress.org/support/article/installing-wordpress-on-your-own-computer/)
 2. Clone / download this repository into your `/wp-content/themes/` directory

--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ You can boot up the Playground with the selected theme by clicking one of the li
 - [Term](https://playground.wordpress.net/?storage=browser&ghexport-repo-url=https://github.com/WordPress/community-themes&ghexport-content-type=theme&ghexport-theme=term#%7B%22steps%22:%5B%7B%22step%22:%22login%22,%22username%22:%22admin%22,%22password%22:%22password%22%7D,%7B%22step%22:%22installTheme%22,%22themeZipFile%22:%7B%22resource%22:%22url%22,%22url%22:%22https://github-proxy.com/proxy.php?action=partial&repo=Wordpress/community-themes&directory=term&branch=trunk%22%7D%7D,%7B%22step%22:%22activateTheme%22,%22themeFolderName%22:%22term%22%7D%5D%7D)
 - [TT1 Blocks](https://playground.wordpress.net/?storage=browser&ghexport-repo-url=https://github.com/WordPress/community-themes&ghexport-content-type=theme&ghexport-theme=tt1-blocks#%7B%22steps%22:%5B%7B%22step%22:%22login%22,%22username%22:%22admin%22,%22password%22:%22password%22%7D,%7B%22step%22:%22installTheme%22,%22themeZipFile%22:%7B%22resource%22:%22url%22,%22url%22:%22https://github-proxy.com/proxy.php?action=partial&repo=Wordpress/community-themes&directory=tt1-blocks&branch=trunk%22%7D%7D,%7B%22step%22:%22activateTheme%22,%22themeFolderName%22:%22tt1-blocks%22%7D%5D%7D)
 
+![CleanShot 2024-05-28 at 10 45 18](https://github.com/WordPress/community-themes/assets/8419292/1a53ce08-6435-4224-8c9b-9fcf551e965d)
+
 #### If you want to work locally:
 
 1. Set up a WordPress instance, here is a [handy guide to install WordPress locally](https://wordpress.org/support/article/installing-wordpress-on-your-own-computer/)


### PR DESCRIPTION
## Description

Today on the contributor's day on WordCamp Porto 2024 I was working on simplifying the process of creating and updating PR by non-developers that are willing to improve community themes.

As it's confusing how to get through GH export form (and it's easy to enter an obstacle if no `storage` option is selected) - this PR automates it.

Additionally, PR does the following:
- Adds links to specific PRs in README that simplify further exporting to PR
- Adds a video / gif showcasing the full process of checking out the theme, editing, and exporting it as PR