### PR TITLE
Update readme files and theme json files to support proper WP versions

### DIFF
--- a/archivist/readme.txt
+++ b/archivist/readme.txt
@@ -1,8 +1,8 @@
 === Archivist ===
-Contributors: the WordPress team
+Contributors: wordpressdotorg
 Requires at least: 6.5
 Tested up to: 6.5.2
-Requires PHP: 5.7
+Requires PHP: 7.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 

--- a/archivist/readme.txt
+++ b/archivist/readme.txt
@@ -1,6 +1,6 @@
 === Archivist ===
 Contributors: the WordPress team
-Requires at least: 6.0
+Requires at least: 6.5
 Tested up to: 6.5.2
 Requires PHP: 5.7
 License: GPLv2 or later

--- a/atlas/readme.txt
+++ b/atlas/readme.txt
@@ -17,7 +17,7 @@ Atlas is a WordPress theme for anyone who wants to take their website to new hei
 
 == Copyright ==
 
-Atlas WordPress Theme, (C) 2022 
+Atlas WordPress Theme, (C) 2022 the WordPress team 
 Atlas is distributed under the terms of the GNU GPL.
 
 This program is free software: you can redistribute it and/or modify

--- a/blue-note/readme.txt
+++ b/blue-note/readme.txt
@@ -1,6 +1,6 @@
 === Blue Note ===
 Contributors: wordpressdotorg
-Requires at least: 6.1
+Requires at least: 6.2
 Tested up to: 6.5
 Requires PHP: 7.4
 License: GPLv2 or later

--- a/poetry/readme.txt
+++ b/poetry/readme.txt
@@ -1,8 +1,8 @@
 === Poetry ===
-Contributors: 
-Requires at least: 5.8
-Tested up to: 5.9
-Requires PHP: 5.7
+Contributors: wordpressdotorg
+Requires at least: 6.5
+Tested up to: 6.5.2
+Requires PHP: 7.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -17,7 +17,7 @@ License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
 == Copyright ==
 
-Poetry WordPress Theme, (C) 2023 
+Poetry WordPress Theme, (C) 2023 the WordPress team 
 Poetry is distributed under the terms of the GNU GPL.
 
 This program is free software: you can redistribute it and/or modify

--- a/purr/readme.txt
+++ b/purr/readme.txt
@@ -1,8 +1,8 @@
 === Purr ===
-Contributors: Draganescu Stefan Andrei
-Requires at least: 6.0
-Tested up to: 6.2
-Requires PHP: 5.7
+Contributors: wordpressdotorg
+Requires at least: 6.5
+Tested up to: 6.5.2
+Requires PHP: 7.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -17,7 +17,7 @@ A status page theme. Resembles the profiles on social networks that used to be n
 
 == Copyright ==
 
-Purr WordPress Theme, (C) 2023 Draganescu Stefan Andrei
+Purr WordPress Theme, (C) 2023 the WordPress team
 Purr is distributed under the terms of the GNU GPL.
 
 This program is free software: you can redistribute it and/or modify

--- a/purr/theme.json
+++ b/purr/theme.json
@@ -210,5 +210,5 @@
 		}
 	],
 	"version": 2,
-	"$schema": "https://schemas.wp.org/trunk/theme.json"
+	"$schema": "https://schemas.wp.org/wp/6.5/theme.json"
 }

--- a/term/readme.txt
+++ b/term/readme.txt
@@ -1,8 +1,8 @@
 === Term ===
 Contributors: 
-Requires at least: 6.0
-Tested up to: 6.4.4-alpha-57488-src
-Requires PHP: 5.7
+Requires at least: 6.5
+Tested up to: 6.5.2
+Requires PHP: 7.4
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -17,7 +17,7 @@ License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
 == Copyright ==
 
-Term WordPress Theme, (C) 2024 
+Term WordPress Theme, (C) 2024 the WordPress team 
 Term is distributed under the terms of the GNU GPL.
 
 This program is free software: you can redistribute it and/or modify

--- a/term/readme.txt
+++ b/term/readme.txt
@@ -1,5 +1,5 @@
 === Term ===
-Contributors: 
+Contributors: wordpressdotorg
 Requires at least: 6.5
 Tested up to: 6.5.2
 Requires PHP: 7.4


### PR DESCRIPTION
This PR updates all the theme.json and readme files to use the proper WordPress version. We shouldn't be using trunk on the schema for themes that are released (or about to be) because the trunk one will have features that are not on the minimum required version of WordPress required by the theme.