### PR TITLE
Actions: only run playground action on PRs that are not forked

### DIFF
--- a/.github/workflows/preview-theme.yml
+++ b/.github/workflows/preview-theme.yml
@@ -1,18 +1,23 @@
 name: Preview Theme Changes
 
 on:
-  pull_request_target:
+  pull_request:
 
 jobs:
   check-for-changes-to-themes:
     runs-on: ubuntu-latest
     steps:
+      - name: Check if PR is from a fork
+        run: |
+          if [ "${{ github.event.pull_request.head.repo.fork }}" == "true" ]; then
+            echo "This pull request is from a fork. Skipping the action."
+            exit 0
+          fi
       - name: Checkout PR Head
         uses: actions/checkout@v2
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
-
       - name: Retrieved Theme Changes
         id: check-for-changes
         run: |


### PR DESCRIPTION
This PR changes the action to only run when the PR is not a fork. This avoids the action failing when the user doesn't have permission to push to the repo