### PR TITLE
Theme preview workflow: use external github action

### DIFF
--- a/.github/workflows/preview-theme.yml
+++ b/.github/workflows/preview-theme.yml
@@ -16,7 +16,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Preview Theme Changes
-        uses: vcanales/action-wp-playground-pr-preview@trunk
+        uses: WordPress/action-wp-playground-pr-preview@trunk
         with: 
           github-token: ${{ secrets.GITHUB_TOKEN }}
           ref: ${{ github.event.pull_request.head.sha }}

--- a/.github/workflows/preview-theme.yml
+++ b/.github/workflows/preview-theme.yml
@@ -1,81 +1,23 @@
 name: Preview Theme Changes
 
 on:
-  pull_request:
+  pull_request_target:
+    types: [opened, synchronize]
+permissions:
+  pull-requests: write
 
 jobs:
-  check-for-changes-to-themes:
+  preview-theme-changes:
     runs-on: ubuntu-latest
     steps:
-      - name: Check if PR is from a fork
-        run: |
-          if [ "${{ github.event.pull_request.head.repo.fork }}" == "true" ]; then
-            echo "This pull request is from a fork. Skipping the action."
-            exit 0
-          fi
-      - name: Checkout PR Head
+      - name: Checkout PR HEAD
         uses: actions/checkout@v2
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-      - name: Retrieved Theme Changes
-        id: check-for-changes
-        run: |
-          # Retrieve list of all changed files
-          git fetch origin ${{ github.event.pull_request.base.ref }}:${{ github.event.pull_request.base.ref }}
-          changed_files=$(git diff --name-only HEAD origin/${{ github.event.pull_request.base.ref }})
-          
-          # Loop through changed files and identify parent directories
-          declare -A unique_dirs
-          for file in $changed_files; do
-            dir_name=$(dirname "$file")
-            while [[ "$dir_name" != "." ]]; do
-              if [[ -f "$dir_name/style.css" ]]; then  # Check if the parent directory contains a theme
-                # Save only the basename
-                unique_dirs[$dir_name]=$(basename $dir_name)
-                break
-              fi
-              dir_name=$(dirname "$dir_name")
-            done
-          done
-          # Check if themes have changed
-          if [[ ${#unique_dirs[@]} -eq 0 ]]; then
-              echo "No theme changes detected"
-              echo "HAS_THEME_CHANGES=false" >> $GITHUB_OUTPUT
-              exit 0 # Use exit code 0 for successful completion
-          fi
-          # Output list of theme slugs with changes
-          echo "HAS_THEME_CHANGES=true" >> $GITHUB_OUTPUT
-          echo "CHANGED_THEMES=$(echo ${unique_dirs[@]})" >> $GITHUB_ENV
-          echo "Theme directories with changes: $CHANGED_THEMES"
-      - name: Add Preview Links comment
-        id: comment-on-pr
-        if: ${{ steps.check-for-changes.outputs.HAS_THEME_CHANGES == 'true' }}
-        uses: actions/github-script@v7
-        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+
+      - name: Preview Theme Changes
+        uses: vcanales/action-wp-playground-pr-preview@trunk
+        with: 
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const createPreviewLinks = require('.github/scripts/create-preview-links');
-            createPreviewLinks(github, context, process.env.CHANGED_THEMES);
-      - name: Remove comment if no changes are detected
-        if: ${{ steps.check-for-changes.outputs.HAS_THEME_CHANGES == 'false' }}
-        uses: actions/github-script@v7
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            const { data: comments } = await github.rest.issues.listComments({
-              issue_number: context.payload.pull_request.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo
-            });
-            
-            const existingComment = comments.find(comment => comment.user.login === 'github-actions[bot]' && comment.body.startsWith('### Preview changes'));
-            
-            if (existingComment) {
-              await github.rest.issues.deleteComment({
-                comment_id: existingComment.id,
-                owner: context.repo.owner,
-                repo: context.repo.repo
-              });
-            }
- 
+          ref: ${{ github.event.pull_request.head.sha }}
+          base-branch: trunk


### PR DESCRIPTION
This proposes using an external copy of the preview themes workflow, which will allow us to run it on `pull_request_target` safely, since the code for the workflow itself lives outside of the repo — this means that the workflow will be able to comment on PRs created by non-members of the WordPress GitHub org.

The code is currently under my GitHub account, but I'll be moving to change ownership to the WordPress org eventually.