### PR TITLE
Poetry: Skip Link missing #244

### DIFF
--- a/poetry/templates/404.html
+++ b/poetry/templates/404.html
@@ -1,13 +1,15 @@
-<!-- wp:template-part {"slug":"header-small","tagName":"header"} /-->
+<!-- wp:template-part {"slug":"header-small","area":"header"} /-->
 
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|80","bottom":"var:preset|spacing|80"},"margin":{"top":"var:preset|spacing|50","bottom":"var:preset|spacing|50"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group" style="margin-top:var(--wp--preset--spacing--50);margin-bottom:var(--wp--preset--spacing--50);padding-top:var(--wp--preset--spacing--80);padding-bottom:var(--wp--preset--spacing--80)"><!-- wp:heading {"textAlign":"center"} -->
-<h2 class="wp-block-heading has-text-align-center">404<br>Not found</h2>
-<!-- /wp:heading -->
-
-<!-- wp:paragraph {"align":"center"} -->
-<p class="has-text-align-center">The server could not find the requested page.</p>
-<!-- /wp:paragraph --></div>
-<!-- /wp:group -->
-
-<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->
+<!-- wp:group {"layout":{"type":"constrained"}} -->
+<main class="wp-block-query has-custom-background-light-background-color has-background">
+    <div class="wp-block-group" style="margin-top:var(--wp--preset--spacing--50);margin-bottom:var(--wp--preset--spacing--50);padding-top:var(--wp--preset--spacing--80);padding-bottom:var(--wp--preset--spacing--80)">
+      <!-- wp:heading {"textAlign":"center"} -->
+      <h2 class="wp-block-heading has-text-align-center">404<br>Not found</h2>
+      <!-- /wp:heading -->
+        <!-- wp:paragraph {"align":"center"} -->
+        <p class="has-text-align-center">The server could not find the requested page.</p>
+        <!-- /wp:paragraph -->
+    </div>
+</main><!-- /wp:group -->
+<!-- wp:template-part {"slug":"footer","area":"footer"} /-->
+    

--- a/poetry/templates/archive.html
+++ b/poetry/templates/archive.html
@@ -1,23 +1,26 @@
 <!-- wp:template-part {"slug":"header-small","area":"header"} /-->
 
 <!-- wp:group {"layout":{"type":"constrained"}} -->
-<div class="wp-block-group"><!-- wp:query-title {"type":"archive","style":{"spacing":{"padding":{"bottom":"var:preset|spacing|40"}}},"fontSize":"x-large"} /-->
-
-<!-- wp:query {"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"layout":{"type":"default"}} -->
-<div class="wp-block-query"><!-- wp:post-template -->
-<!-- wp:post-title {"isLink":true,"style":{"elements":{"link":{"color":{"text":"var:preset|color|custom-text"}}}},"textColor":"custom-text","fontSize":"large"} /-->
-
-<!-- wp:post-featured-image {"isLink":true,"align":"wide"} /-->
-
-<!-- wp:post-excerpt /-->
-
-<!-- wp:separator {"opacity":"css"} -->
-<hr class="wp-block-separator has-css-opacity"/>
-<!-- /wp:separator -->
-
-<!-- wp:post-date /-->
-<!-- /wp:post-template --></div>
-<!-- /wp:query --></div>
-<!-- /wp:group -->
-
+<main class="wp-block-query has-custom-background-light-background-color has-background">
+    <div class="wp-block-group"><!-- wp:query-title {"type":"archive","style":{"spacing":{"padding":{"bottom":"var:preset|spacing|40"}}},"fontSize":"x-large"} /-->
+    
+    <!-- wp:query {"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"layout":{"type":"default"}} -->
+    
+    <div class="wp-block-query"><!-- wp:post-template -->
+    <!-- wp:post-title {"isLink":true,"style":{"elements":{"link":{"color":{"text":"var:preset|color|custom-text"}}}},"textColor":"custom-text","fontSize":"large"} /-->
+    
+    <!-- wp:post-featured-image {"isLink":true,"align":"wide"} /-->
+    
+    <!-- wp:post-excerpt /-->
+    
+    <!-- wp:separator {"opacity":"css"} -->
+    <hr class="wp-block-separator has-css-opacity"/>
+    <!-- /wp:separator -->
+    
+    <!-- wp:post-date /-->
+    <!-- /wp:post-template --></div>
+    
+    <!-- /wp:query --></div>
+</main><!-- /wp:group -->
+    
 <!-- wp:template-part {"slug":"footer","area":"footer"} /-->

--- a/poetry/templates/search.html
+++ b/poetry/templates/search.html
@@ -1,43 +1,44 @@
 <!-- wp:template-part {"slug":"header-small","tagName":"header"} /-->
 
 <!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|80","bottom":"var:preset|spacing|80"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--80);padding-bottom:var(--wp--preset--spacing--80)"><!-- wp:query-title {"type":"search","style":{"spacing":{"padding":{"top":"0","bottom":"0"},"margin":{"top":"0","bottom":"0"}}}} /-->
-
-<!-- wp:search {"label":"Search","showLabel":false,"buttonText":"Search"} /-->
-
-<!-- wp:query {"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"align":"full","layout":{"type":"default"}} -->
-<div class="wp-block-query alignfull"><!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"0","right":"0","bottom":"0","left":"0"}}},"layout":{"type":"constrained"}} -->
-<div class="wp-block-group alignfull" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><!-- wp:post-template {"style":{"typography":{"textTransform":"none"}}} -->
-<!-- wp:group {"style":{"border":{"bottom":{"color":"var:preset|color|contrast","width":"1px"}}},"layout":{"type":"default"}} -->
-<div class="wp-block-group" style="border-bottom-color:var(--wp--preset--color--contrast);border-bottom-width:1px"><!-- wp:group {"style":{"spacing":{"padding":{"top":"16px","right":"16px","bottom":"16px","left":"16px"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
-<div class="wp-block-group" style="padding-top:16px;padding-right:16px;padding-bottom:16px;padding-left:16px"><!-- wp:group {"style":{"spacing":{"blockGap":"4px"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
-<div class="wp-block-group"><!-- wp:paragraph -->
-<p>✴︎</p>
-<!-- /wp:paragraph -->
-
-<!-- wp:post-date {"textAlign":"left","format":"M j, Y","style":{"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"}},"elements":{"link":{"color":{"text":"var:preset|color|contrast"}}},"typography":{"textTransform":"uppercase"}},"textColor":"contrast","fontSize":"small"} /--></div>
-<!-- /wp:group -->
-
-<!-- wp:post-terms {"term":"category","prefix":"✴︎ ","style":{"elements":{"link":{"color":{"text":"var:preset|color|contrast"}}},"typography":{"textTransform":"uppercase"}},"textColor":"contrast"} /--></div>
-<!-- /wp:group --></div>
-<!-- /wp:group -->
-
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"16px","bottom":"var:preset|spacing|70","right":"16px","left":"16px"}}},"layout":{"type":"flex","orientation":"vertical"}} -->
-<div class="wp-block-group" style="padding-top:16px;padding-right:16px;padding-bottom:var(--wp--preset--spacing--70);padding-left:16px"><!-- wp:post-title {"isLink":true,"style":{"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"}},"layout":{"selfStretch":"fit"},"typography":{"fontStyle":"normal","fontWeight":"500","lineHeight":"1.1","textTransform":"uppercase","fontSize":"5.2rem"},"elements":{"link":{"color":{"text":"var:preset|color|contrast"}}}},"textColor":"contrast"} /-->
-
-<!-- wp:post-excerpt /--></div>
-<!-- /wp:group -->
-<!-- /wp:post-template --></div>
-<!-- /wp:group -->
-
-<!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30","right":"16px","left":"16px"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained","justifyContent":"center"}} -->
-<div class="wp-block-group" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--30);padding-right:16px;padding-bottom:var(--wp--preset--spacing--30);padding-left:16px"><!-- wp:query-pagination {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"center"}} -->
-<!-- wp:query-pagination-previous {"label":"Previous","style":{"typography":{"textTransform":"uppercase"}},"fontSize":"small"} /-->
-
-<!-- wp:query-pagination-next {"label":"Next","style":{"typography":{"textTransform":"uppercase"}},"fontSize":"small"} /-->
-<!-- /wp:query-pagination --></div>
-<!-- /wp:group --></div>
-<!-- /wp:query --></div>
-<!-- /wp:group -->
-
-<!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->
+<main class="wp-block-query has-custom-background-light-background-color has-background">
+    <div class="wp-block-group" style="padding-top:var(--wp--preset--spacing--80);padding-bottom:var(--wp--preset--spacing--80)"><!-- wp:query-title {"type":"search","style":{"spacing":{"padding":{"top":"0","bottom":"0"},"margin":{"top":"0","bottom":"0"}}}} /-->
+    
+    <!-- wp:search {"label":"Search","showLabel":false,"buttonText":"Search"} /-->
+    
+    <!-- wp:query {"query":{"perPage":10,"pages":0,"offset":0,"postType":"post","order":"desc","orderBy":"date","author":"","search":"","exclude":[],"sticky":"","inherit":true},"align":"full","layout":{"type":"default"}} -->
+    <div class="wp-block-query alignfull"><!-- wp:group {"align":"full","style":{"spacing":{"padding":{"top":"0","right":"0","bottom":"0","left":"0"}}},"layout":{"type":"constrained"}} -->
+    <div class="wp-block-group alignfull" style="padding-top:0;padding-right:0;padding-bottom:0;padding-left:0"><!-- wp:post-template {"style":{"typography":{"textTransform":"none"}}} -->
+    <!-- wp:group {"style":{"border":{"bottom":{"color":"var:preset|color|contrast","width":"1px"}}},"layout":{"type":"default"}} -->
+    <div class="wp-block-group" style="border-bottom-color:var(--wp--preset--color--contrast);border-bottom-width:1px"><!-- wp:group {"style":{"spacing":{"padding":{"top":"16px","right":"16px","bottom":"16px","left":"16px"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
+    <div class="wp-block-group" style="padding-top:16px;padding-right:16px;padding-bottom:16px;padding-left:16px"><!-- wp:group {"style":{"spacing":{"blockGap":"4px"}},"layout":{"type":"flex","flexWrap":"nowrap"}} -->
+    <div class="wp-block-group"><!-- wp:paragraph -->
+    <p>✴︎</p>
+    <!-- /wp:paragraph -->
+    
+    <!-- wp:post-date {"textAlign":"left","format":"M j, Y","style":{"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"}},"elements":{"link":{"color":{"text":"var:preset|color|contrast"}}},"typography":{"textTransform":"uppercase"}},"textColor":"contrast","fontSize":"small"} /--></div>
+    <!-- /wp:group -->
+    
+    <!-- wp:post-terms {"term":"category","prefix":"✴︎ ","style":{"elements":{"link":{"color":{"text":"var:preset|color|contrast"}}},"typography":{"textTransform":"uppercase"}},"textColor":"contrast"} /--></div>
+    <!-- /wp:group --></div>
+    <!-- /wp:group -->
+    
+    <!-- wp:group {"style":{"spacing":{"padding":{"top":"16px","bottom":"var:preset|spacing|70","right":"16px","left":"16px"}}},"layout":{"type":"flex","orientation":"vertical"}} -->
+    <div class="wp-block-group" style="padding-top:16px;padding-right:16px;padding-bottom:var(--wp--preset--spacing--70);padding-left:16px"><!-- wp:post-title {"isLink":true,"style":{"spacing":{"margin":{"top":"0","right":"0","bottom":"0","left":"0"}},"layout":{"selfStretch":"fit"},"typography":{"fontStyle":"normal","fontWeight":"500","lineHeight":"1.1","textTransform":"uppercase","fontSize":"5.2rem"},"elements":{"link":{"color":{"text":"var:preset|color|contrast"}}}},"textColor":"contrast"} /-->
+    
+    <!-- wp:post-excerpt /--></div>
+    <!-- /wp:group -->
+    <!-- /wp:post-template --></div>
+    <!-- /wp:group -->
+    
+    <!-- wp:group {"style":{"spacing":{"padding":{"top":"var:preset|spacing|30","bottom":"var:preset|spacing|30","right":"16px","left":"16px"},"margin":{"top":"0","bottom":"0"}}},"layout":{"type":"constrained","justifyContent":"center"}} -->
+    <div class="wp-block-group" style="margin-top:0;margin-bottom:0;padding-top:var(--wp--preset--spacing--30);padding-right:16px;padding-bottom:var(--wp--preset--spacing--30);padding-left:16px"><!-- wp:query-pagination {"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"center"}} -->
+    <!-- wp:query-pagination-previous {"label":"Previous","style":{"typography":{"textTransform":"uppercase"}},"fontSize":"small"} /-->
+    
+    <!-- wp:query-pagination-next {"label":"Next","style":{"typography":{"textTransform":"uppercase"}},"fontSize":"small"} /-->
+    <!-- /wp:query-pagination --></div>
+    <!-- /wp:group --></div>
+    <!-- /wp:query --></div>
+    <!-- /wp:group --></main>
+    
+    <!-- wp:template-part {"slug":"footer","tagName":"footer"} /-->


### PR DESCRIPTION
This update addresses the REQUIRED Skip Links missing from the following templates as flagged by the Theme Check plugin:
see screenshort 404 page 
![Screenshot 2025-01-23 at 11 13 03 AM](https://github.com/user-attachments/assets/9795a037-fb7a-41a1-b560-7f1e2e7a53e8)

404.html
archive.html
search.html
Changes Made
Added <main> tags to ensure semantic HTML and improve accessibility.
Implemented Skip Links at the top of the affected templates to allow users to bypass repetitive navigation and access the main content directly.
Files Updated
404.html
archive.html
search.html